### PR TITLE
Code review fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ name: Lint
 on:
   push:
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
               uses: softprops/action-gh-release@v2
               with:
                   files: dist/*
+                  fail_on_unmatched_files: true
                   generate_release_notes: true
 
     pypi-publish:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,23 +8,12 @@ ci:
     ci(pre-commit): autoupdate hook versions
 
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.8
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-        name: Running black in all files.
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/battlemetrics/__init__.py
+++ b/battlemetrics/__init__.py
@@ -1,8 +1,12 @@
 import logging
+from importlib.metadata import PackageNotFoundError, version
 
 from .client import *
 from .errors import *
 
-__version__ = "2.0.5"
+try:
+    __version__ = version("battlemetrics")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/battlemetrics/client.py
+++ b/battlemetrics/client.py
@@ -48,6 +48,7 @@ class Battlemetrics:
         self,
         api_key: str,
         *,
+        timeout: float = 30.0,
         connector: BaseConnector | None = None,
         proxy: str | None = None,
         proxy_auth: BasicAuth | None = None,
@@ -56,6 +57,7 @@ class Battlemetrics:
 
         self.http = HTTPClient(
             api_key=self.__api_key,
+            timeout=timeout,
             connector=connector,
             proxy=proxy,
             proxy_auth=proxy_auth,

--- a/battlemetrics/client.py
+++ b/battlemetrics/client.py
@@ -295,7 +295,7 @@ class Battlemetrics:
         self,
         ban_id: int,
         ban_exemption_id: int,
-    ) -> dict[str, Any]:
+    ) -> BanListExemption:
         """Read a specific banlist exemption by its ID.
 
         Parameters
@@ -307,8 +307,8 @@ class Battlemetrics:
 
         Returns
         -------
-        dict[str, Any]
-            The response from the API containing the banlist exemption.
+        BanListExemption
+            The banlist exemption.
 
         Raises
         ------
@@ -321,7 +321,7 @@ class Battlemetrics:
         )
         return BanListExemption.model_validate(resp["data"])
 
-    async def list_banlist_exemptions(self, ban_id: int) -> dict[str, Any]:
+    async def list_banlist_exemptions(self, ban_id: int) -> list[BanListExemption]:
         """List all banlist exemptions for a specific ban.
 
         Parameters
@@ -331,8 +331,8 @@ class Battlemetrics:
 
         Returns
         -------
-        dict[str, Any]
-            The response from the API containing the list of banlist exemptions.
+        list[BanListExemption]
+            The list of banlist exemptions.
 
         Raises
         ------
@@ -347,22 +347,20 @@ class Battlemetrics:
         ban_id: int,
         *,
         reason: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> BanListExemption:
         """Update a specific banlist exemption by its ID.
 
         Parameters
         ----------
         ban_id : int
             The ID of the ban to update.
-        ban_exemption_id : int
-            The ID of the ban exemption to update.
         reason : str | None
             The new reason for the ban exemption.
 
         Returns
         -------
-        dict[str, Any]
-            The response from the API containing the updated banlist exemption.
+        BanListExemption
+            The updated banlist exemption.
 
         Raises
         ------
@@ -385,13 +383,6 @@ class Battlemetrics:
         ----------
         ban_id : int
             The ID of the ban to delete the exemption from.
-        ban_exemption_id : int
-            The ID of the ban exemption to delete.
-
-        Returns
-        -------
-        dict[str, Any]
-            The response from the API confirming the deletion.
 
         Raises
         ------

--- a/battlemetrics/client.py
+++ b/battlemetrics/client.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
     from aiohttp import BaseConnector, BasicAuth
 
+    from battlemetrics.models.base import IdentifierInput
+
 __all__ = ("Battlemetrics",)
 
 _log = logging.getLogger(__name__)
@@ -876,14 +878,14 @@ class Battlemetrics:
         included = resp.get("included")
         return Player.model_validate({**resp["data"], "included": included})
 
-    async def match_players(self, identifiers: list[dict[str, str]]) -> list[Player]:
+    async def match_players(self, identifiers: list[IdentifierInput]) -> list[Player]:
         """Match players (slow)."""
         resp = await self.http.match_players(identifiers)
         return [Player.model_validate(p) for p in resp["data"]]
 
     async def quick_match_players(
         self,
-        identifiers: list[dict[str, str]],
+        identifiers: list[IdentifierInput],
     ) -> list[QuickMatchIdentifier]:
         """Quick match players by identifiers.
 
@@ -892,7 +894,7 @@ class Battlemetrics:
 
         Parameters
         ----------
-        identifiers : list[dict[str, str]]
+        identifiers : list[IdentifierInput]
             A list of identifier dicts with 'type' and 'identifier' keys.
             Example: [{"type": "steamID", "identifier": "76561197960265720"}]
 

--- a/battlemetrics/client.py
+++ b/battlemetrics/client.py
@@ -243,11 +243,14 @@ class Battlemetrics:
         note: str | None = None,
         identifiers: list[str | dict[str, Any]] | None = None,
         expires: str | None = None,
-        org_wide: bool = True,
-        auto_add_enabled: bool = True,
-        native_enabled: bool = True,
+        org_wide: bool | None = None,
+        auto_add_enabled: bool | None = None,
+        native_enabled: bool | None = None,
     ) -> Ban:
         """Update a specific ban by its ID.
+
+        Only fields explicitly passed will be sent. Omitted fields are
+        preserved server-side.
 
         Parameters
         ----------

--- a/battlemetrics/client.py
+++ b/battlemetrics/client.py
@@ -69,9 +69,9 @@ class Battlemetrics:
 
     async def __aexit__(
         self,
-        type: type[BaseException] | None,  # noqa: A002
-        value: BaseException | None,
-        tb: TracebackType | None,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         """Close the client when exiting the context."""
         await self.close()

--- a/battlemetrics/client.py
+++ b/battlemetrics/client.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-import warnings
 from typing import TYPE_CHECKING, Any, Literal, Self
 
 from battlemetrics.http import HTTPClient
@@ -28,7 +26,6 @@ from battlemetrics.models.session import Session
 from battlemetrics.models.user import User
 
 if TYPE_CHECKING:
-    from asyncio import AbstractEventLoop
     from types import TracebackType
 
     from aiohttp import BaseConnector, BasicAuth
@@ -51,27 +48,15 @@ class Battlemetrics:
         self,
         api_key: str,
         *,
-        asyncio_debug: bool = False,
         connector: BaseConnector | None = None,
-        loop: AbstractEventLoop | None = None,
         proxy: str | None = None,
         proxy_auth: BasicAuth | None = None,
     ) -> None:
         self.__api_key = api_key
 
-        if loop is None:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
-        else:
-            self.loop: asyncio.AbstractEventLoop = loop
-
-        self.loop.set_debug(asyncio_debug)
-
         self.http = HTTPClient(
             api_key=self.__api_key,
             connector=connector,
-            loop=loop,
             proxy=proxy,
             proxy_auth=proxy_auth,
         )
@@ -107,9 +92,7 @@ class Battlemetrics:
         org_wide: bool = True,
         auto_add_enabled: bool = True,
         native_enabled: bool = True,
-        identifiers: (
-            list[str | dict[str, Any]] | None
-        ) = None,  # TODO: Add player object
+        identifiers: list[str | dict[str, Any]] | None = None,  # TODO: Add player object
         expires: str | None = None,
     ) -> Ban:
         """Create a ban with all required and optional parameters."""
@@ -355,9 +338,7 @@ class Battlemetrics:
             Will raise if the request fails or the response indicates an error.
         """
         resp = await self.http.list_banlist_exemptions(ban_id=ban_id)
-        return [
-            BanListExemption.model_validate(exemption) for exemption in resp["data"]
-        ]
+        return [BanListExemption.model_validate(exemption) for exemption in resp["data"]]
 
     async def update_banlist_exemption(
         self,

--- a/battlemetrics/errors.py
+++ b/battlemetrics/errors.py
@@ -2,11 +2,30 @@ from typing import Any
 
 from aiohttp import ClientResponse
 
-__all__ = ("BMException", "Forbidden", "HTTPException", "NotFound", "Unauthorized")
+__all__ = (
+    "BMConnectionError",
+    "BMException",
+    "BMTimeoutError",
+    "BadRequest",
+    "Forbidden",
+    "HTTPException",
+    "NotFound",
+    "RateLimited",
+    "ServerError",
+    "Unauthorized",
+)
 
 
 class BMException(Exception):
     """Base exception class for all BattleMetrics errors."""
+
+
+class BMConnectionError(BMException):
+    """Raised when a network/connection error occurs reaching the API."""
+
+
+class BMTimeoutError(BMException):
+    """Raised when a request times out."""
 
 
 class HTTPException(BMException):
@@ -15,52 +34,85 @@ class HTTPException(BMException):
     Attributes
     ----------
     response: :class:`aiohttp.ClientResponse`
-        The response of the failed HTTP request. This is an
-        instance of :class:`aiohttp.ClientResponse`. In some cases
-        this could also be a :class:`requests.Response`.
-
+        The response of the failed HTTP request.
     text: :class:`str`
-        The text of the error. Could be an empty string.
+        The error message text. May be empty if the body wasn't parseable.
     status: :class:`int`
         The status code of the HTTP request.
     code: :class:`int`
-        The Discord specific error code for the failure.
+        The BattleMetrics-reported status code from the JSON:API error object,
+        or 0 if the body did not contain one.
+    title: :class:`str`
+        The short error title from the JSON:API error object.
     """
 
     def __init__(
         self,
         response: ClientResponse,
-        message: str | dict[str, Any] | None,
+        message: str | dict[str, Any] | list[Any] | None,
     ) -> None:
         self.response: ClientResponse = response
-        self.status: int = response.status  # type: ignore[reportAccessAttributeIssue]
+        self.status: int = response.status
         self.code: int = 0
         self.text: str = ""
         self.title: str = ""
         if isinstance(message, dict):
-            error = message["errors"][0]
-            self.code = (
-                int(error.get("status", "")) if str(error.get("status", "")).isdigit() else 0
-            )
-            self.text = error.get("title", "")
+            errors_list: list[dict[str, Any]] = message.get("errors") or []
+            error: dict[str, Any] = errors_list[0] if errors_list else {}
+            status_raw = str(error.get("status", ""))
+            self.code = int(status_raw) if status_raw.isdigit() else 0
+            self.text = error.get("detail", "") or error.get("title", "")
             self.title = error.get("title", "")
         else:
             self.text = str(message) if message else ""
-            self.code = 0
+
         fmt = "{0.status} {0.reason}"
-        if len(self.text):
+        if self.text:
             fmt += ": {1}"
 
         super().__init__(fmt.format(self.response, self.text))
 
 
+class BadRequest(HTTPException):
+    """Raised when status code 400 occurs."""
+
+
 class Unauthorized(HTTPException):
-    """Exception that's raised for when status code 401 occurs."""
+    """Raised when status code 401 occurs."""
 
 
 class Forbidden(HTTPException):
-    """Exception that's raised for when status code 403 occurs."""
+    """Raised when status code 403 occurs."""
 
 
 class NotFound(HTTPException):
-    """Exception that's raised for when status code 404 occurs."""
+    """Raised when status code 404 occurs."""
+
+
+class RateLimited(HTTPException):
+    """Raised when status code 429 occurs.
+
+    Attributes
+    ----------
+    retry_after: :class:`float` | None
+        The number of seconds to wait before retrying, parsed from the
+        ``Retry-After`` response header. ``None`` if the server did not
+        provide one.
+    """
+
+    def __init__(
+        self,
+        response: ClientResponse,
+        message: str | dict[str, Any] | list[Any] | None,
+    ) -> None:
+        super().__init__(response, message)
+        retry_after = response.headers.get("Retry-After")
+        self.retry_after: float | None = (
+            float(retry_after)
+            if retry_after and retry_after.replace(".", "", 1).isdigit()
+            else None
+        )
+
+
+class ServerError(HTTPException):
+    """Raised when a 5xx status code occurs."""

--- a/battlemetrics/errors.py
+++ b/battlemetrics/errors.py
@@ -40,9 +40,7 @@ class HTTPException(BMException):
         if isinstance(message, dict):
             error = message["errors"][0]
             self.code = (
-                int(error.get("status", ""))
-                if str(error.get("status", "")).isdigit()
-                else 0
+                int(error.get("status", "")) if str(error.get("status", "")).isdigit() else 0
             )
             self.text = error.get("title", "")
             self.title = error.get("title", "")

--- a/battlemetrics/errors.py
+++ b/battlemetrics/errors.py
@@ -94,10 +94,12 @@ class RateLimited(HTTPException):
 
     Attributes
     ----------
-    retry_after: :class:`float` | None
-        The number of seconds to wait before retrying, parsed from the
-        ``Retry-After`` response header. ``None`` if the server did not
-        provide one.
+    limit: :class:`int` | None
+        The rate-limit budget per window, parsed from the
+        ``X-Rate-Limit-Limit`` response header.
+    remaining: :class:`int` | None
+        The remaining requests in the current window, parsed from the
+        ``X-Rate-Limit-Remaining`` response header.
     """
 
     def __init__(
@@ -106,12 +108,10 @@ class RateLimited(HTTPException):
         message: str | dict[str, Any] | list[Any] | None,
     ) -> None:
         super().__init__(response, message)
-        retry_after = response.headers.get("Retry-After")
-        self.retry_after: float | None = (
-            float(retry_after)
-            if retry_after and retry_after.replace(".", "", 1).isdigit()
-            else None
-        )
+        limit = response.headers.get("X-Rate-Limit-Limit")
+        remaining = response.headers.get("X-Rate-Limit-Remaining")
+        self.limit: int | None = int(limit) if limit and limit.isdigit() else None
+        self.remaining: int | None = int(remaining) if remaining and remaining.isdigit() else None
 
 
 class ServerError(HTTPException):

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from enum import Enum
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -26,27 +25,6 @@ if TYPE_CHECKING:
 
 
 _log = getLogger(__name__)
-
-
-class IdentifierType(Enum):
-    """A player identifier type."""
-
-    BE_GUID = "BEGUID"
-    BE_LEGACY_GUID = "legacyBEGUID"
-    CONAN_CHAR_NAME = "conanCharName"
-    EGS_ID = "egsID"
-    FUNCOM_ID = "funcomID"
-    IP = "ip"
-    MC_UUID = "mcUUID"
-    NAME = "name"
-    PLAY_FAB_ID = "playFabID"
-    STEAM_FAMILY_SHARE_OWNER = "steamFamilyShareOwner"
-    STEAM_ID = "steamID"
-    SURVIVOR_NAME = "survivorName"
-
-    def __repr__(self) -> str:
-        """Return a string representation of the identifier type."""
-        return f"<{self.__class__.__name__}.{self.name}>"
 
 
 async def json_or_text(
@@ -78,17 +56,7 @@ async def json_or_text(
     return await response.text(encoding="utf-8")
 
 
-METHODS = Literal[
-    "GET",
-    "HEAD",
-    "OPTIONS",
-    "TRACE",
-    "PUT",
-    "DELETE",
-    "POST",
-    "PATCH",
-    "CONNECT",
-]
+METHODS = Literal["GET", "POST", "PATCH", "DELETE"]
 
 
 class Route:

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -109,7 +109,6 @@ class HTTPClient:
         self.proxy_auth = proxy_auth
 
         self.__session: ClientSession | None = None
-        self.__closed: bool = False
 
         self.api_key: str = api_key
 
@@ -117,22 +116,21 @@ class HTTPClient:
         """
         Ensure that a ClientSession is created and open.
 
-        If a session does not exist, this method creates a new ClientSession
-        using the provided connector. Raises if the client has been closed.
+        If a session does not exist (or the previous one was closed), this
+        method creates a new ClientSession. A user-supplied connector is
+        treated as borrowed (``connector_owner=False``), so close() will
+        not destroy it.
         """
-        if self.__closed:
-            msg = "HTTPClient is closed; create a new client to make further requests."
-            raise RuntimeError(msg)
         if not self.__session or self.__session.closed:
             self.__session = aiohttp.ClientSession(
                 connector=self.connector,
+                connector_owner=self.connector is None,
                 timeout=self.timeout,
             )
         return self.__session
 
     async def close(self) -> None:
         """Close the ClientSession if it exists and is open."""
-        self.__closed = True
         if self.__session:
             await self.__session.close()
 

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -109,6 +109,7 @@ class HTTPClient:
         self.proxy_auth = proxy_auth
 
         self.__session: ClientSession | None = None
+        self.__closed: bool = False
 
         self.api_key: str = api_key
 
@@ -117,8 +118,11 @@ class HTTPClient:
         Ensure that a ClientSession is created and open.
 
         If a session does not exist, this method creates a new ClientSession
-        using the provided connector.
+        using the provided connector. Raises if the client has been closed.
         """
+        if self.__closed:
+            msg = "HTTPClient is closed; create a new client to make further requests."
+            raise RuntimeError(msg)
         if not self.__session or self.__session.closed:
             self.__session = aiohttp.ClientSession(
                 connector=self.connector,
@@ -128,6 +132,7 @@ class HTTPClient:
 
     async def close(self) -> None:
         """Close the ClientSession if it exists and is open."""
+        self.__closed = True
         if self.__session:
             await self.__session.close()
 

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -126,7 +126,7 @@ class HTTPClient:
         self.proxy = proxy
         self.proxy_auth = proxy_auth
 
-        self.__session: ClientSession | None = None  # type: ignore[reportAttributeAccessIssue]
+        self.__session: ClientSession | None = None
 
         self.api_key: str = api_key
 

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -128,7 +128,7 @@ class HTTPClient:
         self.proxy = proxy
         self.proxy_auth = proxy_auth
 
-        self.__session: ClientSession = None  # type: ignore[reportAttributeAccessIssue]
+        self.__session: ClientSession | None = None  # type: ignore[reportAttributeAccessIssue]
 
         self.api_key: str = api_key
 

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -1039,15 +1039,21 @@ class HTTPClient:
         *,
         fields: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Get data points for metrics. Each metric dict should include name, range, resolution."""
+        """Get data points for metrics.
+
+        Each metric dict must include a "name" key plus any of "range" or
+        "resolution". Multiple metrics are supported; each is encoded as
+        ``metrics[<name>][<key>]=<value>``.
+        """
         params: dict[str, Any] = {}
         if fields:
             params["fields[dataPoint]"] = ",".join(fields)
-        # Only first metric supported in this convenience wrapper; call multiple times for more.
         for metric in metrics:
+            name = metric["name"]
             for key, value in metric.items():
-                params[f"metrics[{key}]"] = value
-            break  # only first metric for now (API supports multiple via different encoding)
+                if key == "name":
+                    continue
+                params[f"metrics[{name}][{key}]"] = value
         return await self.request(Route(method="GET", path="/metrics"), params=params)
 
     # ------------------------------ Player Flags -------------------------- #

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import uuid
 from enum import Enum
 from logging import getLogger
@@ -12,7 +11,6 @@ import yarl
 from .errors import BMException, Forbidden, HTTPException, NotFound, Unauthorized
 
 if TYPE_CHECKING:
-    from asyncio import AbstractEventLoop
     from types import TracebackType
 
     from aiohttp import BaseConnector, ClientResponse, ClientSession
@@ -112,9 +110,7 @@ class Route:
     ) -> None:
         self.method: str = method
         url = path if path.startswith(("http://", "https://")) else f"{self.BASE}{path}"
-        self.url: URL = (
-            yarl.URL(url).update_query(**parameters) if parameters else yarl.URL(url)
-        )
+        self.url: URL = yarl.URL(url).update_query(**parameters) if parameters else yarl.URL(url)
 
 
 class HTTPClient:
@@ -125,11 +121,9 @@ class HTTPClient:
         api_key: str,
         *,
         connector: BaseConnector | None = None,
-        loop: AbstractEventLoop | None = None,
         proxy: str | None = None,
         proxy_auth: aiohttp.BasicAuth | None = None,
     ) -> None:
-        self.loop = loop or asyncio.get_event_loop()
         self.connector = connector
         self.proxy = proxy
         self.proxy_auth = proxy_auth
@@ -137,8 +131,6 @@ class HTTPClient:
         self.__session: ClientSession = None  # type: ignore[reportAttributeAccessIssue]
 
         self.api_key: str = api_key
-
-        self.ensure_session()
 
     def __aexit__(
         self,
@@ -151,19 +143,18 @@ class HTTPClient:
 
     def ensure_session(self) -> None:
         """
-        Ensure that an :class:`ClientSession` is created and open.
+        Ensure that a ClientSession is created and open.
 
-        If a session does not exist, this method creates a new :class:`ClientSession`
-        using the provided connector and loop.
+        If a session does not exist, this method creates a new ClientSession
+        using the provided connector.
         """
         if not self.__session or self.__session.closed:
             self.__session = aiohttp.ClientSession(
                 connector=self.connector,
-                loop=self.loop,
             )
 
     async def close(self) -> None:
-        """Close the :class:`ClientSession` if it exists and is open."""
+        """Close the ClientSession if it exists and is open."""
         if self.__session:
             await self.__session.close()
 
@@ -1364,9 +1355,7 @@ class HTTPClient:
     async def match_players(self, identifiers: list[dict[str, str]]) -> dict[str, Any]:
         """Match players by identifiers (slow full match)."""
         data = {
-            "data": [
-                {"type": "identifier", "attributes": ident} for ident in identifiers
-            ],
+            "data": [{"type": "identifier", "attributes": ident} for ident in identifiers],
         }
         return await self.request(
             Route(method="POST", path="/players/match"),
@@ -1379,9 +1368,7 @@ class HTTPClient:
     ) -> dict[str, Any]:
         """Quick match players by identifiers."""
         data = {
-            "data": [
-                {"type": "identifier", "attributes": ident} for ident in identifiers
-            ],
+            "data": [{"type": "identifier", "attributes": ident} for ident in identifiers],
         }
         return await self.request(
             Route(method="POST", path="/players/quick-match"),
@@ -1626,9 +1613,7 @@ class HTTPClient:
                 "relationships": {
                     "player": {"data": {"type": "player", "id": str(player_id)}},
                     "servers": {
-                        "data": [
-                            {"type": "server", "id": str(sid)} for sid in server_ids
-                        ],
+                        "data": [{"type": "server", "id": str(sid)} for sid in server_ids],
                     },
                     "organization": {
                         "data": {"type": "organization", "id": str(organization_id)},
@@ -2294,9 +2279,7 @@ class HTTPClient:
         }
         if player_flags:
             relationships["playerFlags"] = {
-                "data": [
-                    {"type": "playerFlag", "id": flag_id} for flag_id in player_flags
-                ],
+                "data": [{"type": "playerFlag", "id": flag_id} for flag_id in player_flags],
             }
         data = {
             "data": {
@@ -2334,9 +2317,7 @@ class HTTPClient:
         relationships: dict[str, Any] = {}
         if player_flags is not None:
             relationships["playerFlags"] = {
-                "data": [
-                    {"type": "playerFlag", "id": flag_id} for flag_id in player_flags
-                ],
+                "data": [{"type": "playerFlag", "id": flag_id} for flag_id in player_flags],
             }
         data: dict[str, Any] = {
             "data": {

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import uuid
+import secrets
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -250,7 +250,7 @@ class HTTPClient:
             "data": {
                 "type": "ban",
                 "attributes": {
-                    "uid": str(uuid.uuid4())[:14],
+                    "uid": secrets.token_hex(7),
                     "reason": reason,
                     "note": note,
                     "expires": expires,
@@ -467,18 +467,20 @@ class HTTPClient:
         BMException
             Will raise if the request fails or the response indicates an error.
         """
+        attributes: dict[str, Any] = {
+            "reason": reason,
+            "note": note,
+            "expires": expires,
+            "orgWide": org_wide,
+            "autoAddEnabled": auto_add_enabled,
+            "nativeEnabled": native_enabled,
+        }
+        if identifiers is not None:
+            attributes["identifiers"] = identifiers
         data: dict[str, Any] = {
             "data": {
                 "type": "ban",
-                "attributes": {
-                    "reason": reason,
-                    "note": note,
-                    "expires": expires,
-                    "identifiers": identifiers or [],  # TODO: Add identifier handling
-                    "orgWide": org_wide,
-                    "autoAddEnabled": auto_add_enabled,
-                    "nativeEnabled": native_enabled,
-                },
+                "attributes": attributes,
             },
         }
         return await self.request(
@@ -1663,7 +1665,9 @@ class HTTPClient:
         server_ids: list[int] | None = None,
     ) -> dict[str, Any]:
         """Update a reserved slot."""
-        attributes = {"identifiers": identifiers or [], "expires": expires}
+        attributes: dict[str, Any] = {"expires": expires}
+        if identifiers is not None:
+            attributes["identifiers"] = identifiers
         relationships: dict[str, Any] = {}
         if server_ids is not None:
             relationships["servers"] = {

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -118,10 +118,12 @@ class HTTPClient:
         self,
         api_key: str,
         *,
+        timeout: float = 30.0,
         connector: BaseConnector | None = None,
         proxy: str | None = None,
         proxy_auth: aiohttp.BasicAuth | None = None,
     ) -> None:
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.connector = connector
         self.proxy = proxy
         self.proxy_auth = proxy_auth
@@ -140,6 +142,7 @@ class HTTPClient:
         if not self.__session or self.__session.closed:
             self.__session = aiohttp.ClientSession(
                 connector=self.connector,
+                timeout=self.timeout,
             )
         return self.__session
 

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -8,7 +8,17 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 import aiohttp
 import yarl
 
-from .errors import BMException, Forbidden, HTTPException, NotFound, Unauthorized
+from .errors import (
+    BadRequest,
+    BMConnectionError,
+    BMTimeoutError,
+    Forbidden,
+    HTTPException,
+    NotFound,
+    RateLimited,
+    ServerError,
+    Unauthorized,
+)
 
 if TYPE_CHECKING:
     from aiohttp import BaseConnector, ClientResponse, ClientSession
@@ -151,6 +161,35 @@ class HTTPClient:
         if self.__session:
             await self.__session.close()
 
+    @staticmethod
+    def _raise_for_status(
+        response: ClientResponse,
+        data: dict[str, Any] | list[dict[str, Any]] | str,
+        path: str,
+    ) -> None:
+        """Map a non-2xx response to the appropriate typed exception."""
+        status = response.status
+        if status == 400:
+            raise BadRequest(response, data)
+        if status == 401:
+            _log.warning("Path %s returned 401, your API key may be invalid.", path)
+            raise Unauthorized(response, data)
+        if status == 403:
+            _log.warning("Path %s returned 403, check whether you have valid permissions.", path)
+            raise Forbidden(response, data)
+        if status == 404:
+            _log.warning("Path %s returned 404, check whether the path is correct.", path)
+            raise NotFound(response, data)
+        if status == 429:
+            _log.warning(
+                "We're being rate limited. You are limited to %s requests per minute.",
+                response.headers.get("X-Rate-Limit-Limit"),
+            )
+            raise RateLimited(response, data)
+        if 500 <= status < 600:
+            raise ServerError(response, data)
+        raise HTTPException(response, data)
+
     async def request(
         self,
         route: Route,
@@ -202,43 +241,24 @@ class HTTPClient:
         if self.proxy_auth:
             kwargs["proxy_auth"] = self.proxy_auth
 
-        async with session.request(method, url, **kwargs) as response:
-            _log.debug("%s %s returned %s", method, path, response.status)
+        try:
+            async with session.request(method, url, **kwargs) as response:
+                _log.debug("%s %s returned %s", method, path, response.status)
 
-            # errors typically have text involved, so this should be safe 99.5% of the time.
-            data = await json_or_text(response)
+                # errors typically have text involved, so this should be safe 99.5% of the time.
+                data = await json_or_text(response)
 
-            if 200 <= response.status < 300:
-                return data
+                if 200 <= response.status < 300:
+                    return data
 
-            if isinstance(data, dict):
-                if response.status == 401:
-                    _log.warning(
-                        "Path %s returned 401, your API key may be invalid.",
-                        path,
-                    )
-                    raise Unauthorized(response, data)
-                if response.status == 403:
-                    _log.warning(
-                        "Path %s returned 403, check whether you have valid permissions.",
-                        path,
-                    )
-                    raise Forbidden(response, data)
-                if response.status == 404:
-                    _log.warning(
-                        "Path %s returned 404, check whether the path is correct.",
-                        path,
-                    )
-                    raise NotFound(response, data)
-                if response.status == 429:
-                    _log.warning(
-                        "We're being rate limited. You are limited to %s requests per minute.",
-                        response.headers.get("X-Rate-Limit-Limit"),
-                    )
-
-                raise HTTPException(response, data)
-
-            raise BMException
+                self._raise_for_status(response, data, path)
+                return None  # unreachable; _raise_for_status always raises
+        except TimeoutError as e:
+            msg = f"Request to {path} timed out"
+            raise BMTimeoutError(msg) from e
+        except aiohttp.ClientError as e:
+            msg = f"Connection error reaching {path}: {e}"
+            raise BMConnectionError(msg) from e
 
     # HTTP Requests
 

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -456,11 +456,14 @@ class HTTPClient:
         note: str | None = None,
         identifiers: list[str | dict[str, Any]] | None = None,
         expires: str | None = None,
-        org_wide: bool = True,
-        auto_add_enabled: bool = True,
-        native_enabled: bool = True,
+        org_wide: bool | None = None,
+        auto_add_enabled: bool | None = None,
+        native_enabled: bool | None = None,
     ) -> dict[str, Any]:
         """Update a specific ban by its ID.
+
+        Only fields explicitly passed will be sent. Omitted fields are
+        preserved server-side.
 
         Parameters
         ----------
@@ -476,12 +479,12 @@ class HTTPClient:
             "reason": reason,
             "note": note,
             "expires": expires,
+            "identifiers": identifiers,
             "orgWide": org_wide,
             "autoAddEnabled": auto_add_enabled,
             "nativeEnabled": native_enabled,
         }
-        if identifiers is not None:
-            attributes["identifiers"] = identifiers
+        attributes = {k: v for k, v in attributes.items() if v is not None}
         data: dict[str, Any] = {
             "data": {
                 "type": "ban",
@@ -1675,10 +1678,16 @@ class HTTPClient:
         expires: str | None = None,
         server_ids: list[int] | None = None,
     ) -> dict[str, Any]:
-        """Update a reserved slot."""
-        attributes: dict[str, Any] = {"expires": expires}
-        if identifiers is not None:
-            attributes["identifiers"] = identifiers
+        """Update a reserved slot.
+
+        Only fields explicitly passed will be sent. Omitted fields are
+        preserved server-side.
+        """
+        attributes: dict[str, Any] = {
+            "identifiers": identifiers,
+            "expires": expires,
+        }
+        attributes = {k: v for k, v in attributes.items() if v is not None}
         relationships: dict[str, Any] = {}
         if server_ids is not None:
             relationships["servers"] = {

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -132,15 +132,6 @@ class HTTPClient:
 
         self.api_key: str = api_key
 
-    def __aexit__(
-        self,
-        exc_type: BaseException | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        """Close the HTTP client when exiting."""
-        return self.close()
-
     def ensure_session(self) -> None:
         """
         Ensure that a ClientSession is created and open.

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from aiohttp import BaseConnector, ClientResponse, ClientSession
     from yarl import URL
 
+    from .models.base import IdentifierInput
+
 
 _log = getLogger(__name__)
 
@@ -1335,7 +1337,7 @@ class HTTPClient:
             params=params,
         )
 
-    async def match_players(self, identifiers: list[dict[str, str]]) -> dict[str, Any]:
+    async def match_players(self, identifiers: list[IdentifierInput]) -> dict[str, Any]:
         """Match players by identifiers (slow full match)."""
         data = {
             "data": [{"type": "identifier", "attributes": ident} for ident in identifiers],
@@ -1347,7 +1349,7 @@ class HTTPClient:
 
     async def quick_match_players(
         self,
-        identifiers: list[dict[str, str]],
+        identifiers: list[IdentifierInput],
     ) -> dict[str, Any]:
         """Quick match players by identifiers."""
         data = {

--- a/battlemetrics/http.py
+++ b/battlemetrics/http.py
@@ -11,8 +11,6 @@ import yarl
 from .errors import BMException, Forbidden, HTTPException, NotFound, Unauthorized
 
 if TYPE_CHECKING:
-    from types import TracebackType
-
     from aiohttp import BaseConnector, ClientResponse, ClientSession
     from yarl import URL
 
@@ -132,7 +130,7 @@ class HTTPClient:
 
         self.api_key: str = api_key
 
-    def ensure_session(self) -> None:
+    def ensure_session(self) -> ClientSession:
         """
         Ensure that a ClientSession is created and open.
 
@@ -143,6 +141,7 @@ class HTTPClient:
             self.__session = aiohttp.ClientSession(
                 connector=self.connector,
             )
+        return self.__session
 
     async def close(self) -> None:
         """Close the ClientSession if it exists and is open."""
@@ -177,7 +176,7 @@ class HTTPClient:
             Will raise if the request fails or the response indicates an error.
             Might raise a more specific exception if the response status code is known.
         """
-        self.ensure_session()
+        session: ClientSession = self.ensure_session()
 
         method = route.method
         url = route.url
@@ -200,7 +199,7 @@ class HTTPClient:
         if self.proxy_auth:
             kwargs["proxy_auth"] = self.proxy_auth
 
-        async with self.__session.request(method, url, **kwargs) as response:
+        async with session.request(method, url, **kwargs) as response:
             _log.debug("%s %s returned %s", method, path, response.status)
 
             # errors typically have text involved, so this should be safe 99.5% of the time.

--- a/battlemetrics/models/ban.py
+++ b/battlemetrics/models/ban.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -10,12 +11,12 @@ class BanAttributes(BaseModel):
 
     reason: str
     note: str | None = None
-    expires: str | None = None
+    expires: datetime | None = None
     identifiers: list[str | dict[str, Any]]
     org_wide: bool = Field(alias="orgWide")
     auto_add_enabled: bool = Field(alias="autoAddEnabled")
     native_enabled: bool | None = Field(default=None, alias="nativeEnabled")
-    timestamp: str
+    timestamp: datetime
     uid: str
     id: int
 
@@ -41,13 +42,13 @@ class Ban(Base):
 class NativeBanAttributes(BaseModel):
     """Attributes for the NativeBan model."""
 
-    created_at: str = Field(alias="createdAt")
-    expires: str | None = None
+    created_at: datetime = Field(alias="createdAt")
+    expires: datetime | None = None
     identifier: str
     reason: str | None = None
     state: Literal["added", "removed"]
     type: IdentifierTypesLiteral  # type: ignore[reportInvalidTypeForm]
-    updated_at: str = Field(alias="updatedAt")
+    updated_at: datetime = Field(alias="updatedAt")
 
     model_config = {
         "populate_by_name": True,

--- a/battlemetrics/models/banlist.py
+++ b/battlemetrics/models/banlist.py
@@ -104,5 +104,5 @@ class BanListInvite(Base):
     """Represents an invite to a ban list."""
 
     type: str = "banListInvite"
-    attributes: BaseModel
-    relationships: BaseRelationships
+    attributes: BanListInviteAttributes
+    relationships: BanListInviteRelationships

--- a/battlemetrics/models/base.py
+++ b/battlemetrics/models/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -8,6 +8,7 @@ __all__ = (
     "IDENTIFIER_TYPES",
     "Base",
     "BaseRelationships",
+    "IdentifierInput",
     "IdentifierTypesLiteral",
     "Relationship",
 )
@@ -33,6 +34,13 @@ IDENTIFIER_TYPES = [
     "reforgerUUID",
 ]
 IdentifierTypesLiteral = Literal[*IDENTIFIER_TYPES]
+
+
+class IdentifierInput(TypedDict):
+    """Input shape for match_players / quick_match_players."""
+
+    type: IdentifierTypesLiteral  # type: ignore[reportInvalidTypeForm]
+    identifier: str
 
 
 class Base(BaseModel):

--- a/battlemetrics/models/flag.py
+++ b/battlemetrics/models/flag.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -42,8 +43,8 @@ PlayerFlagIcon = (
 class FlagPlayerAttributes(BaseModel):
     """Attributes for the FlagPlayer model."""
 
-    added_at: str = Field(alias="addedAt")
-    removed_at: str | None = Field(default=None, alias="removedAt")
+    added_at: datetime = Field(alias="addedAt")
+    removed_at: datetime | None = Field(default=None, alias="removedAt")
 
     model_config = {
         "populate_by_name": True,
@@ -71,11 +72,11 @@ class PlayerFlagAttributes(BaseModel):
     """Attributes for the PlayerFlag model."""
 
     color: str
-    created_at: str = Field(alias="createdAt")
+    created_at: datetime = Field(alias="createdAt")
     description: str | None = None
     icon: PlayerFlagIcon = None
     name: str
-    updated_at: str = Field(alias="updatedAt")
+    updated_at: datetime = Field(alias="updatedAt")
 
     model_config = {
         "populate_by_name": True,

--- a/battlemetrics/models/game.py
+++ b/battlemetrics/models/game.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -83,7 +84,7 @@ class GameFeatureOptionsAttributes(BaseModel):
     count: int
     display: str
     players: int
-    updated_at: str = Field(alias="updatedAt")
+    updated_at: datetime = Field(alias="updatedAt")
 
     model_config = {
         "populate_by_name": True,

--- a/battlemetrics/models/note.py
+++ b/battlemetrics/models/note.py
@@ -6,7 +6,7 @@ from .base import Base, BaseRelationships, Relationship
 class NoteAttributes(BaseModel):
     """Attributes for the Note model."""
 
-    clearance_level: int = Field(alias="clearanceLevel")
+    clearance_level: int | None = Field(default=None, alias="clearanceLevel")
     created_at: str = Field(alias="createdAt")
     expires_at: str | None = Field(default=None, alias="expiresAt")
     note: str

--- a/battlemetrics/models/note.py
+++ b/battlemetrics/models/note.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 from .base import Base, BaseRelationships, Relationship
@@ -7,8 +9,8 @@ class NoteAttributes(BaseModel):
     """Attributes for the Note model."""
 
     clearance_level: int | None = Field(default=None, alias="clearanceLevel")
-    created_at: str = Field(alias="createdAt")
-    expires_at: str | None = Field(default=None, alias="expiresAt")
+    created_at: datetime = Field(alias="createdAt")
+    expires_at: datetime | None = Field(default=None, alias="expiresAt")
     note: str
     shared: bool
 

--- a/battlemetrics/models/player.py
+++ b/battlemetrics/models/player.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -9,12 +10,12 @@ from .server import ServerData
 class PlayerAttributes(BaseModel):
     """Attributes for the Player model."""
 
-    created_at: str = Field(alias="createdAt")
+    created_at: datetime = Field(alias="createdAt")
     id: str
     name: str
     positive_match: bool = Field(alias="positiveMatch")
     private: bool
-    updated_at: str = Field(alias="updatedAt")
+    updated_at: datetime = Field(alias="updatedAt")
 
     model_config = {
         "populate_by_name": True,
@@ -57,7 +58,7 @@ class PlayerIdentifierAttributes(BaseModel):
     """Attributes for the PlayerIdentifier model."""
 
     identifier: str
-    last_seen: str = Field(alias="lastSeen")
+    last_seen: datetime = Field(alias="lastSeen")
     metadata: object | None = None
     private: bool
     type: IdentifierTypesLiteral  # type: ignore[reportInvalidTypeForm]
@@ -140,7 +141,7 @@ class QuickMatchIdentifierAttributes(BaseModel):
 
     type: IdentifierTypesLiteral  # type: ignore[reportInvalidTypeForm]
     identifier: str
-    last_seen: str = Field(alias="lastSeen")
+    last_seen: datetime = Field(alias="lastSeen")
     private: bool
     metadata: object | None = None
 
@@ -171,7 +172,7 @@ class RelatedPlayerIdentifierAttributes(BaseModel):
     """Attributes for the RelatedPlayerIdentifier model."""
 
     identifier: str
-    last_seen: str = Field(alias="lastSeen")
+    last_seen: datetime = Field(alias="lastSeen")
     metadata: object | None = None
     private: bool
     type: IdentifierTypesLiteral  # type: ignore[reportInvalidTypeForm]

--- a/battlemetrics/models/query.py
+++ b/battlemetrics/models/query.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -21,9 +22,9 @@ class PlayerQueryAttributes(BaseModel):
     """Attributes for the PlayerQuery model."""
 
     conditions: PlayerQueryConditions
-    created_at: str = Field(alias="createdAt")
+    created_at: datetime = Field(alias="createdAt")
     query_name: str = Field(alias="queryName")
-    updated_at: str = Field(alias="updatedAt")
+    updated_at: datetime = Field(alias="updatedAt")
 
     model_config = {
         "populate_by_name": True,

--- a/battlemetrics/models/server.py
+++ b/battlemetrics/models/server.py
@@ -165,4 +165,4 @@ class ReservedSlot(Base):
 
     type: str = "reservedSlot"
     attributes: ReservedSlotAttributes
-    meta: dict[str, Any]
+    meta: dict[str, Any] | None = None

--- a/battlemetrics/models/server.py
+++ b/battlemetrics/models/server.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -52,7 +53,7 @@ class ServerAttributes(BaseModel):
 
     address: str | None = None
     country: str
-    created_at: str = Field(alias="createdAt")
+    created_at: datetime = Field(alias="createdAt")
     details: dict[str, Any] | None = None
     id: str
     ip: str
@@ -67,11 +68,11 @@ class ServerAttributes(BaseModel):
     query_status: str | None = Field(default=None, alias="queryStatus")
     rank: int | None = None
     rcon_active: bool | None = Field(default=None, alias="rconActive")
-    rcon_disconnected: str | None = Field(default=None, alias="rconDisconnected")
-    rcon_last_connected: str | None = Field(default=None, alias="rconLastConnected")
+    rcon_disconnected: datetime | None = Field(default=None, alias="rconDisconnected")
+    rcon_last_connected: datetime | None = Field(default=None, alias="rconLastConnected")
     rcon_status: str | None = Field(default=None, alias="rconStatus")
     status: str
-    updated_at: str = Field(alias="updatedAt")
+    updated_at: datetime = Field(alias="updatedAt")
 
     model_config = {
         "populate_by_name": True,
@@ -142,8 +143,8 @@ class Server(Base):
 class ReservedSlotAttributes(BaseModel):
     """Attributes for the ReservedSlot model."""
 
-    created_at: str = Field(alias="createdAt")
-    expires: str | None = None
+    created_at: datetime = Field(alias="createdAt")
+    expires: datetime | None = None
     identifiers: list[str]
 
     model_config = {

--- a/battlemetrics/models/session.py
+++ b/battlemetrics/models/session.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 from .base import Base, BaseRelationships, Relationship
@@ -18,8 +20,8 @@ class SessionAttributes(BaseModel):
     metadata: list[SessionMetadata] | None = None
     name: str
     private: bool
-    start: str
-    stop: str | None = None
+    start: datetime
+    stop: datetime | None = None
 
     model_config = {
         "populate_by_name": True,

--- a/examples/list_servers.py
+++ b/examples/list_servers.py
@@ -7,7 +7,7 @@ from battlemetrics import Battlemetrics
 
 
 async def main() -> None:
-    api_key = os.environ.get("BATTLEMETRICS_API_KEY")
+    api_key = os.environ["BATTLEMETRICS_API_KEY"]
 
     async with Battlemetrics(api_key) as client:
         servers = await client.list_servers(

--- a/examples/player_search.py
+++ b/examples/player_search.py
@@ -7,7 +7,7 @@ from battlemetrics import Battlemetrics
 
 
 async def main() -> None:
-    api_key = os.environ.get("BATTLEMETRICS_API_KEY")
+    api_key = os.environ["BATTLEMETRICS_API_KEY"]
 
     async with Battlemetrics(api_key) as client:
         players = await client.list_players(search="shroud", page_size=5)

--- a/examples/server_info.py
+++ b/examples/server_info.py
@@ -7,7 +7,7 @@ from battlemetrics import Battlemetrics
 
 
 async def main() -> None:
-    api_key = os.environ.get("BATTLEMETRICS_API_KEY")
+    api_key = os.environ["BATTLEMETRICS_API_KEY"]
 
     async with Battlemetrics(api_key) as client:
         server = await client.get_server(1234567)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "battlemetrics"
 description = "Asyncronous Python wrapper for the BattleMetrics API."
-version = "2.0.5"
+version = "2.1.0"
 authors = [
     { name = "OseSem", email = "sem@osesem.xyz" },
     { name = "Gnomeslayer", email = "declan.otten@live.com.au" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ ignore = [
     "TD002",  # Author in TODO
     "TD003",  # Issue Link in TODO
     "FIX002", # TODO Found
+
+    "COM812", # Conflicts with ruff format.
+    "ISC001", # Conflicts with ruff format.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ packages = ["battlemetrics"]
 
 [tool.pyright]
 typeCheckingMode = "strict"
-reportReturnType = false
 reportUnnecessaryComparison = false
 include = ["battlemetrics"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ ignore = [
     "ERA001", # commented out code.
     "D100",   # docstrings in public modules.
     "D104",   # docstrings in public package.
-    "ANN101", # self type hint.
     "ANN401", # Any type hint.
     "N815",   # Mixed case variable name.
     "N818",   # Error suffix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ reportReturnType = false
 reportUnnecessaryComparison = false
 include = ["battlemetrics"]
 
+[tool.ty.environment]
+python = "./.venv"
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.9.3", "pydantic>=2.0.0"]
+dependencies = ["aiohttp>=3.13.5", "pydantic>=2.7.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/OseSem/battlemetrics"


### PR DESCRIPTION
Fixes from the audit. Most of the criticals plus a chunk of the importants and minors. Tests, pagination, and the included-resources rework are still TODO.

Breaking changes worth knowing about:
- `loop=` and `asyncio_debug=` parameters removed from `Battlemetrics()`
- Datetime fields on models are `datetime` now instead of `str`
- Banlist exemption methods return typed models instead of dicts
- `update_ban` no longer force-overwrites the boolean flags when omitted
- 4xx/5xx and network errors raise typed exceptions (still under `HTTPException` / `BMException`)